### PR TITLE
Delisting Inactive Requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ http://ibm.biz/quantum-careers
 Learn more about the application process by reading *Apply for a Summer 2021 IBM Quantum Internship* on the IBM Research Blog:  
 https://ibm.co/quantuminternships
 
-_For IBM Quantum internships in the United States, please apply by Monday, November 2, 2020 in order to receive the best chance at consideration._
-
-We will be opening applications for 2021 internship roles in countries outside of the United States at a later date.
-
 Applicants should submit their resumes to the appropriate job requisite(s) listed below. Cover letters and recommendation letters are _not_ required as part of your application.
 
 ### Quantum Researcher Internships
@@ -20,17 +16,9 @@ Research interns will have the opportunity to focus on experiments, theory, or q
 
 Locations:
 
-- IBM Thomas J. Watson Research Center (Yorktown Heights, New York, USA)
-- IBM Research — Almaden (San Jose, California, USA)
 - IBM Research - Tokyo (Tokyo, Japan)
 - IBM Research - Haifa (Haifa, Israel)
 - IBM Research - Zurich (Zurich, Switzerland)
-
-PhD Quantum Research Summer Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/962203/PhD-Quantum-Research-Summer-Intern-2021/
-
-Master’s Quantum Research Summer Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/962207/Master's-Quantum-Research-Summer-Intern-2021/?lang=en
 
 2021 IBM Quantum Research Summer Intern (Japan):
 
@@ -49,39 +37,15 @@ https://www.zurich.ibm.com/careers/2020_048.html
 
 Developer interns will have the opportunity to focus on kernel, algorithm, or model development. Areas of focus could include quantum machine learning, quantum biology and health informatics, quantum algorithms for chemistry, quantum simulations, quantum optimization, cloud microservices, and cloud API (among other areas).
 
-Locations:
+We are not currently accepting new applications for IBM Quantum developer internships.
 
-- IBM Thomas J. Watson Research Center (Yorktown Heights, New York, USA)
-- IBM Research — Almaden (San Jose, California, USA)
-
-PhD Quantum Developer Summer Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/962210/PhD-Quantum-Developer-Summer-Intern-2021/
-
-Graduate Quantum Developer Summer Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/962202/Graduate-Quantum-Developer-Summer-Intern-2021/
-
-Undergraduate Quantum Developer Summer Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/962204/Undergraduate-Quantum-Developer-Summer-Intern-2021/
 
 ### Quantum Engineer Internships
 
 Engineering interns will have the opportunity to focus on hardware or software engineering. Areas of engineering could include superconducting qubits, quantum software architecture, cryoelectronic circuit design, quantum microwave engineering, and quantum FPGA engineering (among other areas).
 
-Locations:
+We are not currently accepting new applications for IBM Quantum engineer internships.
 
-- IBM Thomas J. Watson Research Center (Yorktown Heights, New York, USA)
-- IBM Research — Almaden (San Jose, California, USA)
-- IBM Systems Lab — Rochester, Minnesota, USA
-- IBM Systems Lab — Poughkeepsie, New York, USA
-
-PhD Quantum Engineering (United States):  
-https://careers.ibm.com/ShowJob/Id/962213/PhD-Quantum-Engineering-Summer-Intern-2021/
-
-Graduate Quantum Engineering Summer Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/962214/Graduate-Quantum-Engineering-Summer-Intern-2021/
-
-Undergraduate Quantum Engineering Summer Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/962215/Undergraduate-Quantum-Engineering-Summer-Intern-2021/
 
 ### Quantum Community Advocate Internships
 
@@ -121,37 +85,18 @@ https://www.zurich.ibm.com/careers/2020_050.html
 
 ### Quantum Designer Internships
 
-Locations:
+We are not currently accepting new applications for IBM Quantum designer internships.
 
-- IBM Thomas J. Watson Research Center (Yorktown Heights, New York, USA)
-- IBM Research — Austin, Texas, USA
-
-IBM Quantum Design Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/982781/IBM-Quantum-Design-Intern-2021/
 
 ### Quantum Offering Manager Internships
 
-Locations:
+We are not currently accepting new applications for IBM Quantum offering manager internships.
 
-- IBM Thomas J. Watson Research Center (Yorktown Heights, New York, USA)
-- IBM Research — Almaden (San Jose, California, USA)
-
-IBM Quantum Offering Manager Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/981532/IBM-Quantum-Offering-Manager-Intern-2021/
 
 ## Early Professional (full-time) Roles
 
 IBM Quantum Research Staff Member (United States):  
 https://careers.ibm.com/ShowJob/Id/986522/IBM-Quantum-Research-Staff-Member-2021/
-
-IBM Quantum Entry Level Hardware Developer (United States):  
-https://careers.ibm.com/ShowJob/Id/986523/IBM-Quantum-Entry-Level-Hardware-Developer-2021/
-
-IBM Quantum Entry Level Developer (United States):  
-https://careers.ibm.com/ShowJob/Id/981311/IBM-Quantum-Entry-Level-Developer-2021/
-
-IBM Quantum Entry Level Engineer (United States):  
-https://careers.ibm.com/ShowJob/Id/980973/IBM-Quantum-Entry-Level-Engineer-2021/
 
 Postdoctoral Researcher (United States):  
 https://careers.ibm.com/ShowJob/Id/955997/2021-Postdoctoral-Researcher/


### PR DESCRIPTION
De-listing the links for job requisites no longer open for new applications