### PR TITLE
Closing out applications for 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,13 @@ Learn about [internship opportunities](https://www.ibm.com/quantum-computing/int
 
 ## Internships
 
-Learn more about the application process by reading *Apply for a Summer 2021 IBM Quantum Internship* on the IBM Research Blog:  
-https://ibm.co/quantuminternships
-
-Applicants should submit their resumes to the appropriate job requisite(s) listed below. Cover letters and recommendation letters are _not_ required as part of your application.
+We have concluded the application period for our 2021 class of summer interns. Please check back for information about how to apply for 2022 internships later this year!
 
 ### Quantum Researcher Internships
 
 Research interns will have the opportunity to focus on experiments, theory, or quantum information science. Areas of research could include superconducting qubits, quantum control, quantum error correction, quantum complexity theory, quantum algorithms, quantum machine learning, and quantum compilers and optimizers (among other areas).
 
-Locations:
-
-- IBM Research - Tokyo (Tokyo, Japan)
-- IBM Research - Haifa (Haifa, Israel)
-- IBM Research - Zurich (Zurich, Switzerland)
-
-2021 IBM Quantum Research Summer Intern (Japan):
-
-(English) https://careers.ibm.com/ShowJob/Id/1027652/[IBM-Quantum]Research-Tokyo-Student-Intern%EF%BC%88Paid-Intern_TRL%EF%BC%89%E3%80%90IBM-Japan%E3%80%91/ 
-
-(日本語) https://careers.ibm.com/ShowJob/Id/1027704/[IBM-Quantum]Research-Tokyo-Student-Intern%EF%BC%88Paid-Intern_TRL%EF%BC%89%E3%80%90IBM-Japan%E3%80%91/ 
-
-2021 IBM Quantum Research Summer Intern (Israel):
-https://careers.ibm.com/ShowJob/Id/1026743/Quantum-Summer-Intern-Research-Lab/ 
-
-Master's student or intern - Cryogenic CMOS data converters for qubit control and readout (Switzerland):
-https://www.zurich.ibm.com/careers/2020_048.html
-
+We are not currently accepting new applications for IBM Quantum researcher internships.
 
 ### Quantum Developer Internships
 
@@ -48,46 +28,22 @@ We are not currently accepting new applications for IBM Quantum engineer interns
 
 ### Quantum Community Advocate Internships
 
-Locations:
+Community advocate interns work on projects related to quantum education, community events, and open-source software, among other areas of focus. The ideal candidate must be able to work with internal and external stakeholders in order to deliver a positive experience for quantum computing community members.
 
-- IBM United States (Multiple Cities, USA)
-- IBM Japan (Tokyo, Japan)
-- IBM South Africa (Sandton, Gauteng, South Africa)
-- IBM Switzerland (Zurich, Switzerland)
+We are not currently accepting new applications for IBM Quantum community advocate internships.
 
-IBM Quantum Community Advocate Intern (United States):  
-https://careers.ibm.com/ShowJob/Id/980793/IBM%20Quantum%20Community%20Advocate%20Intern%20%20%202021
-
-IBM Quantum Community Writing Intern - 2021 (United States):
-https://careers.ibm.com/ShowJob/Id/1060222/IBM-Quantum-Community-Writing-Intern-2021/
-
-2021 IBM Quantum Community Advocate Intern (Japan):
-
-(English) https://careers.ibm.com/ShowJob/Id/1027649/[Quantum-Advocate]Tokyo-Student-Intern%EF%BC%88Paid-Intern_TRL%EF%BC%89%E3%80%90IBM-Japan%E3%80%91/ 
-
-(日本語) https://careers.ibm.com/ShowJob/Id/1027703/[Quantum-Advocate]Tokyo-Student-Intern%EF%BC%88Paid-Intern_TRL%EF%BC%89%E3%80%90IBM-Japan%E3%80%91/ 
-
-2021 IBM Quantum Community Advocate Intern (South Africa):
-https://careers.ibm.com/ShowJob/Id/1017317/IBM-Quantum-Community-Advocate-Intern/ 
-
-Community Advocate Intern - Quantum Computing (Switzerland):
-https://www.zurich.ibm.com/careers/2020_050.html
 
 ### Quantum Designer Internships
+
+Design interns will have the opportunity to work on projects related to design research, user experience design, or visual design. They will work to uncover insights into the worldwide quantum computing community, and share quantum knowledge with users from the first introduction to quantum through quantum computing research and development.
 
 We are not currently accepting new applications for IBM Quantum designer internships.
 
 
 ### Quantum Offering Manager Internships
 
+Offering manager interns will have the opportunity to work on products across the IBM Quantum portfolio. The ideal candidate must be able to work with internal and external stakeholders in order to deliver a positive experience for quantum computing community members.
+
 We are not currently accepting new applications for IBM Quantum offering manager internships.
 
-
-## Full Time Roles
-
-IBM Quantum System Software Developer (Yorktown Heights, NY or remote):
-https://careers.ibm.com/ShowJob/Id/1002296/IBM-Quantum-System-Software-Developer-(Yorktown-Heights,-NY-or-remote)/
-
-IBM Quantum System Performance Engr (Yorktown Heights, NY or remote):
-https://careers.ibm.com/ShowJob/Id/1050774/IBM-Quantum-System-Performance-Engr-(Yorktown-Heights,-NY-or-remote)/
 


### PR DESCRIPTION
Removing dead links for 2021 applications and updating verbiage to reflect that we have completed our application gathering for 2021. Also added general descriptors for the intern positions that didn't have them so that future interns will have some idea of what each category is.